### PR TITLE
Persist broker reference in Database status

### DIFF
--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -150,6 +150,10 @@ type DatabaseStatus struct {
 	// +optional
 	DeploymentID string `json:"deploymentId,omitempty"`
 
+	// BrokerRef references the Broker CR that handled this deployment
+	// +optional
+	BrokerRef *ObjectReference `json:"brokerRef,omitempty"`
+
 	// Cost information
 	// +optional
 	Cost *CostInfo `json:"cost,omitempty"`
@@ -210,4 +214,10 @@ type DatabaseList struct {
 
 func init() {
 	SchemeBuilder.Register(&Database{}, &DatabaseList{})
+}
+
+// ObjectReference is a reference to another Kubernetes object
+type ObjectReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }

--- a/config/crd/bases/platform.company.com_databases.yaml
+++ b/config/crd/bases/platform.company.com_databases.yaml
@@ -1,0 +1,308 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: databases.platform.company.com
+spec:
+  group: platform.company.com
+  names:
+    kind: Database
+    listKind: DatabaseList
+    plural: databases
+    singular: database
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.engine
+      name: Engine
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.size
+      name: Size
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Database is the Schema for the databases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatabaseSpec defines the desired state of Database
+            properties:
+              backup:
+                description: Backup configuration
+                properties:
+                  enabled:
+                    description: Enabled determines if backups are enabled
+                    type: boolean
+                  pointInTimeRestore:
+                    description: PointInTimeRestore enables PITR
+                    type: boolean
+                  retention:
+                    description: Retention period (e.g., "7d", "30d")
+                    pattern: ^\d+[dhm]$
+                    type: string
+                  schedule:
+                    description: Schedule in cron format
+                    type: string
+                required:
+                - enabled
+                - retention
+                type: object
+              encryption:
+                description: Encryption configuration
+                properties:
+                  atRest:
+                    description: AtRest encryption configuration
+                    properties:
+                      enabled:
+                        description: Enabled determines if encryption at rest is enabled
+                        type: boolean
+                      kmsKeyId:
+                        description: KMSKeyID specifies the KMS key (optional, uses
+                          default if not specified)
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  inTransit:
+                    description: InTransit encryption configuration
+                    properties:
+                      enabled:
+                        description: Enabled determines if TLS is required
+                        type: boolean
+                      minTLSVersion:
+                        description: MinTLSVersion specifies minimum TLS version
+                        enum:
+                        - 1.2
+                        - 1.3
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                required:
+                - atRest
+                - inTransit
+                type: object
+              engine:
+                description: Engine specifies the database engine (postgresql, mysql,
+                  mongodb, etc.)
+                enum:
+                - postgresql
+                - mysql
+                - mongodb
+                - redis
+                - sqlserver
+                type: string
+              highAvailability:
+                description: HighAvailability enables HA configuration
+                type: boolean
+              owner:
+                description: Owner reference to the owning Application or Team
+                properties:
+                  kind:
+                    description: Kind of the owner (Team, Application)
+                    enum:
+                    - Team
+                    - Application
+                    type: string
+                  name:
+                    description: Name of the owner
+                    type: string
+                  namespace:
+                    description: Namespace of the owner (if namespaced)
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              parameters:
+                additionalProperties:
+                  type: string
+                description: Parameters for database-specific configuration
+                type: object
+              size:
+                description: Size specifies the instance size
+                enum:
+                - small
+                - medium
+                - large
+                - xlarge
+                type: string
+              target:
+                description: Target specifies where to deploy (e.g., azure-westus2-prod)
+                type: string
+              version:
+                description: Version specifies the engine version
+                minLength: 1
+                type: string
+            required:
+            - engine
+            - owner
+            - size
+            - version
+            type: object
+          status:
+            description: DatabaseStatus defines the observed state of Database
+            properties:
+              cloudResourceId:
+                description: CloudResourceID is the cloud provider's resource identifier
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectionSecretRef:
+                description: ConnectionSecretRef references the secret containing
+                  connection details
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              cost:
+                description: Cost information
+                properties:
+                  currency:
+                    description: Currency code
+                    type: string
+                  estimatedMonthly:
+                    description: EstimatedMonthly in USD
+                    type: number
+                  lastUpdated:
+                    description: LastUpdated timestamp
+                    format: date-time
+                    type: string
+                required:
+                - currency
+                - estimatedMonthly
+                - lastUpdated
+                type: object
+              deploymentId:
+                description: DeploymentID from the broker
+                type: string
+              brokerRef:
+                description: BrokerRef references the Broker CR that handled this deployment
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              endpoint:
+                description: Endpoint is the connection endpoint
+                type: string
+              lastBackup:
+                description: LastBackup timestamp
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation most recently
+                  observed
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current state
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Failed
+                - Deleting
+                type: string
+              port:
+                description: Port is the connection port
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Store selected Broker name/namespace in Database.Status.BrokerRef and prefer it for deprovision. Updates API types, CRD schema, and controller logic.